### PR TITLE
Prepare for release v0.0.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	k8s.io/client-go v0.21.2
 	kmodules.xyz/client-go v0.0.0-20211013093146-1fbfd52e78c9
 	sigs.k8s.io/yaml v1.2.0
-	voyagermesh.dev/apimachinery v0.1.3-0.20211016164718-21c78451aa5d
+	voyagermesh.dev/apimachinery v0.1.3
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -987,5 +987,5 @@ sigs.k8s.io/structured-merge-diff/v4 v4.1.0/go.mod h1:bJZC9H9iH24zzfZ/41RGcq60oK
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=
 sigs.k8s.io/yaml v1.2.0 h1:kr/MCeFWJWTwyaHoR9c8EjH9OumOmoF9YGiZd7lFm/Q=
 sigs.k8s.io/yaml v1.2.0/go.mod h1:yfXDCHCao9+ENCvLSE62v9VSji2MKu5jeNfTrofGhJc=
-voyagermesh.dev/apimachinery v0.1.3-0.20211016164718-21c78451aa5d h1:RFO7TBeQL7adlSg8Hla/dFe2RtAp1b/ivUgLlvhJW8M=
-voyagermesh.dev/apimachinery v0.1.3-0.20211016164718-21c78451aa5d/go.mod h1:IZ5mzlQHKq7rApRaF0tGlcKeJ1ZH87CbsjgmmYJ43q8=
+voyagermesh.dev/apimachinery v0.1.3 h1:6sLXCGcHJArel6SW92+bwKdrKobbdSDXy7NEhGIAG+A=
+voyagermesh.dev/apimachinery v0.1.3/go.mod h1:IZ5mzlQHKq7rApRaF0tGlcKeJ1ZH87CbsjgmmYJ43q8=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -529,7 +529,7 @@ sigs.k8s.io/structured-merge-diff/v4/value
 # sigs.k8s.io/yaml v1.2.0
 ## explicit; go 1.12
 sigs.k8s.io/yaml
-# voyagermesh.dev/apimachinery v0.1.3-0.20211016164718-21c78451aa5d
+# voyagermesh.dev/apimachinery v0.1.3
 ## explicit; go 1.16
 voyagermesh.dev/apimachinery/apis/voyager
 voyagermesh.dev/apimachinery/apis/voyager/v1


### PR DESCRIPTION
ProductLine: Voyager
Release: v2021.10.18
Release-tracker: https://github.com/voyagermesh/CHANGELOG/pull/10
Signed-off-by: 1gtm <1gtm@appscode.com>