### PR TITLE
Prepare for release v0.0.7

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	k8s.io/klog/v2 v2.9.0
 	kmodules.xyz/client-go v0.0.0-20220203031013-1de48437aaf3
 	sigs.k8s.io/yaml v1.2.0
-	voyagermesh.dev/apimachinery v0.4.0
+	voyagermesh.dev/apimachinery v0.4.1
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -1103,5 +1103,5 @@ sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=
 sigs.k8s.io/yaml v1.2.0 h1:kr/MCeFWJWTwyaHoR9c8EjH9OumOmoF9YGiZd7lFm/Q=
 sigs.k8s.io/yaml v1.2.0/go.mod h1:yfXDCHCao9+ENCvLSE62v9VSji2MKu5jeNfTrofGhJc=
 sourcegraph.com/sourcegraph/appdash v0.0.0-20190731080439-ebfcffb1b5c0/go.mod h1:hI742Nqp5OhwiqlzhgfbWU4mW4yO10fP+LoT9WOswdU=
-voyagermesh.dev/apimachinery v0.4.0 h1:EAO8tBMFfuTOQC31TLv0bjWzUHcmleNRjvdiHzRjoy8=
-voyagermesh.dev/apimachinery v0.4.0/go.mod h1:lA6aiKEejHH6/sPKO6c9HiT84t/9pZtDax/NlV55xkU=
+voyagermesh.dev/apimachinery v0.4.1 h1:hsaCJaskDqTYjgS1jKV/azo82fiNEgy/uRBxqje4uDU=
+voyagermesh.dev/apimachinery v0.4.1/go.mod h1:lA6aiKEejHH6/sPKO6c9HiT84t/9pZtDax/NlV55xkU=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -535,7 +535,7 @@ sigs.k8s.io/structured-merge-diff/v4/value
 # sigs.k8s.io/yaml v1.2.0
 ## explicit; go 1.12
 sigs.k8s.io/yaml
-# voyagermesh.dev/apimachinery v0.4.0
+# voyagermesh.dev/apimachinery v0.4.1
 ## explicit; go 1.16
 voyagermesh.dev/apimachinery/apis/voyager
 voyagermesh.dev/apimachinery/apis/voyager/v1

--- a/vendor/voyagermesh.dev/apimachinery/apis/voyager/v1/annotations.go
+++ b/vendor/voyagermesh.dev/apimachinery/apis/voyager/v1/annotations.go
@@ -284,9 +284,7 @@ const (
 	AgentInterval = EngressKey + "/" + "agent-interval"
 )
 
-var (
-	get = map[string]meta.GetFunc{}
-)
+var get = map[string]meta.GetFunc{}
 
 func registerParser(key string, fn meta.ParserFunc) { get[key] = meta.ParseFor(key, fn) }
 func init() {

--- a/vendor/voyagermesh.dev/apimachinery/apis/voyager/v1/ingress.go
+++ b/vendor/voyagermesh.dev/apimachinery/apis/voyager/v1/ingress.go
@@ -243,7 +243,7 @@ type IngressRule struct {
 // mixing different types of rules in a single Ingress is disallowed, so exactly
 // one of the following must be set.
 type IngressRuleValue struct {
-	//TODO:
+	// TODO:
 	// 1. Consider renaming this resource and the associated rules so they
 	// aren't tied to Ingress. They can be used to route intra-cluster traffic.
 	// 2. Consider adding fields for Ingress-type specific global options

--- a/vendor/voyagermesh.dev/apimachinery/apis/voyager/v1/validator.go
+++ b/vendor/voyagermesh.dev/apimachinery/apis/voyager/v1/validator.go
@@ -117,7 +117,7 @@ func (r Ingress) IsValid(cloudProvider string) error {
 			}
 
 			var a *address
-			var addrKey = fmt.Sprintf("%s:%d", bindAddress, podPort)
+			addrKey := fmt.Sprintf("%s:%d", bindAddress, podPort)
 
 			if ea, found := addrs[addrKey]; found {
 				if ea.Protocol == "tcp" {
@@ -210,7 +210,7 @@ func (r Ingress) IsValid(cloudProvider string) error {
 			}
 
 			var a *address
-			var addrKey = fmt.Sprintf("%s:%d", bindAddress, podPort)
+			addrKey := fmt.Sprintf("%s:%d", bindAddress, podPort)
 
 			if ea, found := addrs[addrKey]; found {
 				if ea.Protocol != "tcp" {
@@ -424,7 +424,7 @@ func checkOptionalAddress(address string) (string, error) {
 }
 
 func checkExclusiveWildcard(address string, port int, defined map[string]*address) error {
-	var wildcard = fmt.Sprintf("*:%d", port)
+	wildcard := fmt.Sprintf("*:%d", port)
 
 	if address == "*" {
 		// If a wildcard already exists for the port, we've passed validation for this port before.

--- a/vendor/voyagermesh.dev/apimachinery/apis/voyager/v1beta1/ingress.go
+++ b/vendor/voyagermesh.dev/apimachinery/apis/voyager/v1beta1/ingress.go
@@ -246,7 +246,7 @@ type IngressRule struct {
 // mixing different types of rules in a single Ingress is disallowed, so exactly
 // one of the following must be set.
 type IngressRuleValue struct {
-	//TODO:
+	// TODO:
 	// 1. Consider renaming this resource and the associated rules so they
 	// aren't tied to Ingress. They can be used to route intra-cluster traffic.
 	// 2. Consider adding fields for Ingress-type specific global options


### PR DESCRIPTION
ProductLine: Voyager
Release: v2022.03.17
Release-tracker: https://github.com/voyagermesh/CHANGELOG/pull/17
Signed-off-by: 1gtm <1gtm@appscode.com>