### PR TITLE
Prepare for release v0.0.8

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	k8s.io/klog/v2 v2.9.0
 	kmodules.xyz/client-go v0.0.0-20220203031013-1de48437aaf3
 	sigs.k8s.io/yaml v1.2.0
-	voyagermesh.dev/apimachinery v0.4.1
+	voyagermesh.dev/apimachinery v0.4.2
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -1103,5 +1103,5 @@ sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=
 sigs.k8s.io/yaml v1.2.0 h1:kr/MCeFWJWTwyaHoR9c8EjH9OumOmoF9YGiZd7lFm/Q=
 sigs.k8s.io/yaml v1.2.0/go.mod h1:yfXDCHCao9+ENCvLSE62v9VSji2MKu5jeNfTrofGhJc=
 sourcegraph.com/sourcegraph/appdash v0.0.0-20190731080439-ebfcffb1b5c0/go.mod h1:hI742Nqp5OhwiqlzhgfbWU4mW4yO10fP+LoT9WOswdU=
-voyagermesh.dev/apimachinery v0.4.1 h1:hsaCJaskDqTYjgS1jKV/azo82fiNEgy/uRBxqje4uDU=
-voyagermesh.dev/apimachinery v0.4.1/go.mod h1:lA6aiKEejHH6/sPKO6c9HiT84t/9pZtDax/NlV55xkU=
+voyagermesh.dev/apimachinery v0.4.2 h1:FhT6ZDrtOtSDLA6D3OO/02BUOC6TseV85pG2o7967S4=
+voyagermesh.dev/apimachinery v0.4.2/go.mod h1:NjC/3ouNbOyCu0lo3FIMAi0M1wnnrfPgoN1sXBk+OA8=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -535,7 +535,7 @@ sigs.k8s.io/structured-merge-diff/v4/value
 # sigs.k8s.io/yaml v1.2.0
 ## explicit; go 1.12
 sigs.k8s.io/yaml
-# voyagermesh.dev/apimachinery v0.4.1
+# voyagermesh.dev/apimachinery v0.4.2
 ## explicit; go 1.16
 voyagermesh.dev/apimachinery/apis/voyager
 voyagermesh.dev/apimachinery/apis/voyager/v1


### PR DESCRIPTION
ProductLine: Voyager
Release: v2022.04.13
Release-tracker: https://github.com/voyagermesh/CHANGELOG/pull/18
Signed-off-by: 1gtm <1gtm@appscode.com>