### PR TITLE
Prepare for release v0.0.10

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	k8s.io/klog/v2 v2.70.1
 	kmodules.xyz/client-go v0.24.6-0.20220817193607-c52ad2a6e732
 	sigs.k8s.io/yaml v1.3.0
-	voyagermesh.dev/apimachinery v0.5.1-0.20220817211505-8f8ef7fd670d
+	voyagermesh.dev/apimachinery v0.6.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -556,5 +556,5 @@ sigs.k8s.io/structured-merge-diff/v4 v4.2.3 h1:PRbqxJClWWYMNV1dhaG4NsibJbArud9kF
 sigs.k8s.io/structured-merge-diff/v4 v4.2.3/go.mod h1:qjx8mGObPmV2aSZepjQjbmb2ihdVs8cGKBraizNC69E=
 sigs.k8s.io/yaml v1.3.0 h1:a2VclLzOGrwOHDiV8EfBGhvjHvP46CtW5j6POvhYGGo=
 sigs.k8s.io/yaml v1.3.0/go.mod h1:GeOyir5tyXNByN85N/dRIT9es5UQNerPYEKK56eTBm8=
-voyagermesh.dev/apimachinery v0.5.1-0.20220817211505-8f8ef7fd670d h1:7YxbEVlw6vv3k5EPNI6mvurSUs8qIY4MncIf9eyaCKc=
-voyagermesh.dev/apimachinery v0.5.1-0.20220817211505-8f8ef7fd670d/go.mod h1:MUuzCA4LNsb5OqTJjUoaAP0I8q+nMalwIxzYkCiLtgU=
+voyagermesh.dev/apimachinery v0.6.0 h1:9GNfuz69FLpR7n1yq/XEaMplIRrGL+zPUQTb52xnHZA=
+voyagermesh.dev/apimachinery v0.6.0/go.mod h1:MUuzCA4LNsb5OqTJjUoaAP0I8q+nMalwIxzYkCiLtgU=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -504,7 +504,7 @@ sigs.k8s.io/structured-merge-diff/v4/value
 # sigs.k8s.io/yaml v1.3.0
 ## explicit; go 1.12
 sigs.k8s.io/yaml
-# voyagermesh.dev/apimachinery v0.5.1-0.20220817211505-8f8ef7fd670d
+# voyagermesh.dev/apimachinery v0.6.0
 ## explicit; go 1.18
 voyagermesh.dev/apimachinery/apis/voyager
 voyagermesh.dev/apimachinery/apis/voyager/v1


### PR DESCRIPTION
ProductLine: Voyager
Release: v2022.08.17
Release-tracker: https://github.com/voyagermesh/CHANGELOG/pull/20
Signed-off-by: 1gtm <1gtm@appscode.com>